### PR TITLE
Updated demo url in readme to github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ BUI is built to be modular. An application can load regular bootstrap, then when
 
 ## Demo
  
-[http://decipher-design.com/bui/]()
+[http://decipherinc.github.io/bui](http://decipherinc.github.io/bui)
 
 ## Currently Available Overrides
 


### PR DESCRIPTION
The README link to the demo page pointed to an outdated repo. Updated this to use github pages as the demo source.